### PR TITLE
Adding depth indicator variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Showing current directory.
 | BULLETTRAIN_CAR_DIRECTORY_SEPARATOR_SYMBOL | Override the car's right hand side separator symbol.                                       | Using global symbol.              |
 | BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT       | Set the number of parent directories displayed. Setting it to 0 means to show all of them. | 3                                 |
 | BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR   | Set a custom path separator character.                                                     | Using the OS's path separator.    |
+| BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR  | Indicator of too deep directory structure.                                                 | ...                               |
 
 ### OS Car
 

--- a/car_directory/dir.go
+++ b/car_directory/dir.go
@@ -58,12 +58,19 @@ func (c *Car) Render(out chan<- string) {
 			}
 		}
 
+		// Allow to override the default three dots by some other string.
+		depth_indicator := "..."
+		di, di_defined := os.LookupEnv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR")
+		if di_defined {
+			depth_indicator = di
+		}
+
 		// Compose directory segments.
 		dirs := strings.Split(dir, ps)
 		if max_length > 0 && len(dirs) > max_length+1 {
 			f := len(dirs) - max_length
 			p := dirs[f:]
-			dir = fmt.Sprintf("...%s", strings.Join(p, ps))
+			dir = fmt.Sprintf("%s%s", depth_indicator, strings.Join(p, ps))
 		}
 
 		if s := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR"); s != "" {


### PR DESCRIPTION
This PR is introducing a new variable (`BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR`) to adjust the directory depth indicator. That will allow to change the default `...` in front of the directory name by any other set of characters. If the variable is set to an empty string, only the directory name is displayed with no depth indicator.