### PR TITLE
Enhance the experience of dir car

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ releases/
 !releases/.gitkeep
 vendor/
 /tmp/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ releases/
 !releases/.gitkeep
 vendor/
 /tmp/
-.idea

--- a/README.md
+++ b/README.md
@@ -380,17 +380,18 @@ Showing current directory.
 
 **Options**
 
-| Environment variable                       | Description                                                                                           | Default value                     |
-|:-------------------------------------------|:------------------------------------------------------------------------------------------------------|:----------------------------------|
-| BULLETTRAIN_CAR_DIRECTORY_SHOW             | Whether the car needs to be shown.                                                                    | true                              |
-| BULLETTRAIN_CAR_DIRECTORY_PAINT            | Colour override for the car's paint.                                                                  | white:blue                        |
-| BULLETTRAIN_CAR_DIRECTORY_SEPARATOR_PAINT  | Colour override for the car's right hand side separator paint.                                        | Using default painting algorythm. |
-| BULLETTRAIN_CAR_DIRECTORY_SEPARATOR_SYMBOL | Override the car's right hand side separator symbol.                                                  | Using global symbol.              |
-| BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR   | Set a custom path separator character.                                                                | ``                               |
-| BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT       | Set the number of parent directories displayed. Setting it to 0 means to show all of them.            | 3                                 |
-| BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR  | Indicator of too deep directory structure.                                                            | `...`                             |
-| BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW        | Whether the root separator should be displayed. When enabled, the root directory is always displayed. | true                              |
-| BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW   | Whether to keep showing the first directory when the path is shortened. e.g.: /usr                    | true                              |
+| Environment variable                       | Description                                                                                                                                                 | Default value                     |
+|:-------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------|
+| BULLETTRAIN_CAR_DIRECTORY_SHOW             | Whether the car needs to be shown.                                                                                                                          | true                              |
+| BULLETTRAIN_CAR_DIRECTORY_PAINT            | Colour override for the car's paint.                                                                                                                        | white:blue                        |
+| BULLETTRAIN_CAR_DIRECTORY_SEPARATOR_PAINT  | Colour override for the car's right hand side separator paint.                                                                                              | Using default painting algorythm. |
+| BULLETTRAIN_CAR_DIRECTORY_SEPARATOR_SYMBOL | Override the car's right hand side separator symbol.                                                                                                        | Using global symbol.              |
+| BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR   | Set a custom path separator character.                                                                                                                      | ``                             |
+| BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH | Set the number of parent directories's front displayed. Setting it to negative means to show all of directories.                                            | 2                                 |
+| BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH  | Set the number of parent directories's tail displayed. Setting it to negative means to show all of directories.                                             | 2                                 |
+| BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR  | Indicator of too deep directory structure in `merge` mode.                                                                                                  | `...`                             |
+| BULLETTRAIN_CAR_DIRECTORY_ELLIPSIS         | Ellipsis symbol of directory name in `acronym` mode.                                                                                                        | `*`                               |
+| BULLETTRAIN_CAR_DIRECTORY_ABBREVIATE_MODE  | Abbreviate mode of too deep directory structure. Set to `merge` for using "/usr/lib/.../pkg" style, set to `acronym` for using "/user/lib/g*/s*/pkg" style. | `acronym`                         |
 
 ### OS Car
 

--- a/bullettrain.go
+++ b/bullettrain.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"os/user"
 	"regexp"
 	"strings"
@@ -105,20 +104,15 @@ func main() {
 		fmt.Println("")
 		fmt.Printf("%+q", n.String())
 	} else {
+		fmt.Println("")
 		fmt.Print(n.String())
 	}
 }
 
 // pwd returns the current directory path.
 func pwd() string {
-	cmd := exec.Command("pwd", "-P")
-	pwd, err := cmd.Output()
-	var d string
-	if err == nil {
-		d = strings.Trim(string(pwd), "\n")
-	}
-
-	return d
+	pwd, _ := os.Getwd()
+	return pwd
 }
 
 func carsOrder() (o []string) {

--- a/src/car/directory/dir.go
+++ b/src/car/directory/dir.go
@@ -58,8 +58,9 @@ func rebuildDirForRender(directory string) string {
 		sep = separatorSymbol
 	}
 
-	if strings.HasPrefix(directory, os.Getenv("HOME")) {
-		directory = strings.Replace(directory, os.Getenv("HOME"), "~", 1)
+	home := os.Getenv("HOME")
+	if home != "" && strings.HasPrefix(directory, home) {
+		directory = strings.Replace(directory, home, "~", 1)
 	}
 
 	directoryParts := strings.Split(directory, string(os.PathSeparator))

--- a/src/car/directory/dir.go
+++ b/src/car/directory/dir.go
@@ -83,14 +83,14 @@ func rebuildDirForRender(directory string) string {
 	if l > frontMaxLength+tailMaxLength && frontMaxLength > 0 && tailMaxLength > 0 {
 		var partsReconstruct []string
 
-		acronymMode := "acronym"
-		if e := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE"); e != "" {
-			acronymMode = e
+		abbreviateMode := "acronym"
+		if e := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_ABBREVIATE_MODE"); e != "" {
+			abbreviateMode = e
 		}
 
 		partsReconstruct = append(partsReconstruct, directoryParts[0:frontMaxLength]...)
 
-		switch acronymMode {
+		switch abbreviateMode {
 		case "merge":
 			var di string
 			if di = os.Getenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR"); di == "" {

--- a/src/car/directory/dir.go
+++ b/src/car/directory/dir.go
@@ -72,7 +72,7 @@ func rebuildDirForRender(directory string) string {
 		}
 	}
 
-	tailMaxLength := 1
+	tailMaxLength := 2
 	if e := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH"); e != "" {
 		if ml, err := strconv.ParseInt(e, 10, 32); err == nil {
 			tailMaxLength = int(ml)
@@ -82,29 +82,33 @@ func rebuildDirForRender(directory string) string {
 	if l > frontMaxLength+tailMaxLength && frontMaxLength > 0 && tailMaxLength > 0 {
 		var partsReconstruct []string
 
-		acronymMode := true
-		if e := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE"); e == "false" {
-			acronymMode = false
+		acronymMode := "acronym"
+		if e := os.Getenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE"); e != "" {
+			acronymMode = e
 		}
 
 		partsReconstruct = append(partsReconstruct, directoryParts[0:frontMaxLength]...)
 
-		if acronymMode {
+		switch acronymMode {
+		case "merge":
+			var di string
+			if di = os.Getenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR"); di == "" {
+				di = depthIndicator
+			}
+			partsReconstruct = append(partsReconstruct, di)
+		default:
 			var es string
 			if es = os.Getenv("BULLETTRAIN_CAR_DIRECTORY_ELLIPSIS"); es == "" {
 				es = ellipsisSymbol
 			}
 
-			for _, part := range directoryParts[frontMaxLength:len(directoryParts)-tailMaxLength] {
-				partsReconstruct = append(partsReconstruct, part[:1] + es)
+			for _, part := range directoryParts[frontMaxLength : len(directoryParts)-tailMaxLength] {
+				if len(part) > 1 {
+					partsReconstruct = append(partsReconstruct, part[:1]+es)
+				} else {
+					partsReconstruct = append(partsReconstruct, part)
+				}
 			}
-		} else{
-			var di string
-			if di = os.Getenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR"); di == "" {
-				di = depthIndicator
-			}
-
-			partsReconstruct = append(partsReconstruct, di)
 		}
 
 		partsReconstruct = append(partsReconstruct, directoryParts[len(directoryParts)-tailMaxLength:]...)

--- a/src/car/directory/dir_test.go
+++ b/src/car/directory/dir_test.go
@@ -47,7 +47,7 @@ func TestMergeMode(t *testing.T) {
 	setup()
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "2")
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH", "1")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE", "merge")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ABBREVIATE_MODE", "merge")
 	directory := filepath.Clean("/usr/share/doc/vpn/easy")
 	expected := "usr...easy"
 
@@ -92,7 +92,7 @@ func TestCustomAcronymSymbol(t *testing.T) {
 
 func TestCustomDepthIndicator(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE", "merge")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ABBREVIATE_MODE", "merge")
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR", "+++")
 	directory := filepath.Clean(filepath.Clean("/usr/share/doc/vpn/easy"))
 	expected := "usr+++vpneasy"

--- a/src/car/directory/dir_test.go
+++ b/src/car/directory/dir_test.go
@@ -2,6 +2,7 @@ package carDirectory
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -9,32 +10,14 @@ const failTpl = "Unexpected directory format.\nEXPECTED: %s\nGOT:      %s"
 
 func setup() {
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR", "")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "3")
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR", "...")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "true")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
 }
 
 func TestFullPath(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "0")
-	directory := "/usr/share/doc/vpn/easy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "-1")
+	directory := filepath.Clean("/usr/share/doc/vpn/easy")
 	expected := "usrsharedocvpneasy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestWithoutRoot(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "0")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usrsharedocvpneasy"
 
 	actual := rebuildDirForRender(directory)
 
@@ -48,8 +31,8 @@ func TestCustomPathSeparator(t *testing.T) {
 	setup()
 	sep := "|"
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_PATH_SEPARATOR", sep)
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "5")
-	directory := "/usr/share/doc/vpn/easy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "-1")
+	directory := filepath.Clean("/usr/share/doc/vpn/easy")
 	expected := "|usr|share|doc|vpn|easy"
 
 	actual := rebuildDirForRender(directory)
@@ -60,13 +43,13 @@ func TestCustomPathSeparator(t *testing.T) {
 	}
 }
 
-func TestFirstDirShowingLength2(t *testing.T) {
+func TestMergeMode(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "2")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usr...easy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "2")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH", "1")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE", "merge")
+	directory := filepath.Clean("/usr/share/doc/vpn/easy")
+	expected := "usr...easy"
 
 	actual := rebuildDirForRender(directory)
 
@@ -76,13 +59,12 @@ func TestFirstDirShowingLength2(t *testing.T) {
 	}
 }
 
-func TestFirstDirNotShowingLength2(t *testing.T) {
+func TestAcronymMode(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "2")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "false")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "...vpneasy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "2")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH", "1")
+	directory := filepath.Clean("/usr/share/doc/vpn/easy")
+	expected := "usrs*d*v*easy"
 
 	actual := rebuildDirForRender(directory)
 
@@ -92,93 +74,13 @@ func TestFirstDirNotShowingLength2(t *testing.T) {
 	}
 }
 
-func TestFirstDirNotShowingFullLength(t *testing.T) {
+func TestCustomAcronymSymbol(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "0")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "false")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usrsharedocvpneasy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestFirstDirNotShowingLength1(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "1")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "false")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "...easy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestFirstDirShowingFullLength(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "0")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usrsharedocvpneasy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestFirstDirShowingLength1(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "1")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usr...easy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestFirstDirShowingLength3(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "3")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usr...vpneasy"
-
-	actual := rebuildDirForRender(directory)
-
-	if actual != expected {
-		t.Logf(failTpl, expected, actual)
-		t.Fail()
-	}
-}
-
-func TestFirstDirNotShowingLength3(t *testing.T) {
-	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "3")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "false")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "...docvpneasy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ELLIPSIS", "~")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "2")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_TAIL_MAX_LENGTH", "1")
+	directory := filepath.Clean(filepath.Clean("/usr/share/doc/vpn/easy"))
+	expected := "usrs~d~v~easy"
 
 	actual := rebuildDirForRender(directory)
 
@@ -190,12 +92,10 @@ func TestFirstDirNotShowingLength3(t *testing.T) {
 
 func TestCustomDepthIndicator(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "3")
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ACRONYM_MODE", "merge")
 	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_DEPTH_INDICATOR", "+++")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_ROOT_SHOW", "false")
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FIRST_DIR_SHOW", "true")
-	directory := "/usr/share/doc/vpn/easy"
-	expected := "usr+++vpneasy"
+	directory := filepath.Clean(filepath.Clean("/usr/share/doc/vpn/easy"))
+	expected := "usr+++vpneasy"
 
 	actual := rebuildDirForRender(directory)
 
@@ -207,10 +107,10 @@ func TestCustomDepthIndicator(t *testing.T) {
 
 func TestHomeDirectoryShorthand(t *testing.T) {
 	setup()
-	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_MAX_LENGHT", "5")
-	os.Setenv("HOME", "/home/ikon")
-	directory := "/home/ikon/doc/vpn/easy"
-	expected := "~docvpneasy"
+	os.Setenv("BULLETTRAIN_CAR_DIRECTORY_FRONT_MAX_LENGTH", "-1")
+	os.Setenv("HOME", filepath.Clean("/home/ikon"))
+	directory := filepath.Clean("/home/ikon/doc/vpn/easy")
+	expected := "~docvpneasy"
 
 	actual := rebuildDirForRender(directory)
 


### PR DESCRIPTION
## Description
This PR enhances the experience of dir car, I have done three main changes in this PR.

01. Use the `os.Getwd()`  instead of `pwd` command to getting work directory, it will not resolve the symbolic link.  
02. Add abbreviate mode(`acronym`) for the too deep directory, it will show with `/user/lib/g*/s*/pkg`.
03. Separate the max length to two variables, you can control the front part and tail part independently.
04. Change the behavior of showing the root separator and first dir.

## Why do this?
I will explain in detail why I made these changes.

### Use the `os.Getwd()`
I think the shell prompt should not to resolve the symbolic link to the physical path, using the physical path can lead to confusion when using relative paths (ex. `../../../`).

I will show you an example.
If I am in the `/home/higan/data` currently, it just a symbolic link of "/mnt/c/users/higan/data".
Now I input `>cd ../..`, I will go to `/home`, but not `/mnt/c/users/`

### Add acronym mode
In my use, I often get confused about how deep of the directory because I just get a ... for this.

So I have added the acronym mode, it will show your directory deep, every middle directory will show as initials and an ellipsis symbol (default to *)
You can get `~/go/s*/g*/bullettrain-sh/bullettrain-go-core` for deep directory.

### Separate max length
Everyone’s focus is different, separate it will be helpful for customized requirements in different abbreviate mode.

### Not to show separator before home(~)
In previous versions, we just set the root directory separator in a general way.
But in fact, we should not show separator before ~, it shouldn't be `/~`. And we should add a separator before root directory.

![Snipaste_2019-05-28_21-55-48](https://user-images.githubusercontent.com/9367842/58484286-586a1180-8194-11e9-9ab6-2d12b667882c.png)
