### PR TITLE
Add k8s car support

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -15,13 +15,14 @@ import (
 	"github.com/bullettrain-sh/bullettrain-go-php"
 	"github.com/bullettrain-sh/bullettrain-go-python"
 	"github.com/bullettrain-sh/bullettrain-go-ruby"
+	"github.com/devkanro/bullettrain-go-k8s"
 )
 
 const (
-	defaultCarOrder    = "os time date user host dir python go ruby nodejs php git status"
-	separatorSymbol    = ""
+	defaultCarOrder = "os k8s time date user host dir python go ruby nodejs php git status"
+	separatorSymbol = ""
 	// language=GoTemplate
-	separatorTemplate  = `{{.Icon | printf "%s " | c}}`
+	separatorTemplate = `{{.Icon | printf "%s " | c}}`
 	// language=GoTemplate
 	promptCharTemplate = `{{.Icon | printf "%s " | c}}`
 )
@@ -43,5 +44,6 @@ func trailers(currentWorkingDir string) map[string]carRenderer {
 		"status":  &carStatus.Car{},
 		"openvpn": &carOpenvpn.Car{},
 		"time":    &carTime.Car{},
+		"k8s":     &carK8s.Car{},
 	}
 }


### PR DESCRIPTION
## Description
This PR add k8s context support for bullettrain-sh.

I would like to transfer [the k8s car repo](https://github.com/devkanro/bullettrain-go-k8s) to bullettrain-sh organization.

## Features:

- Displaying only when kubectl installed
- Kubernetes context display


**Callword**: `k8s`

**Template variables**:

* `.Icon`: the car's icon
* `.Context`: the Kubernetes context text

**Template colours**:

* `c`: the car's colour


## Car options

| Environment variable                  | Description                                                    | Default value                                   |
|:--------------------------------------|:---------------------------------------------------------------|:------------------------------------------------|
| BULLETTRAIN_CAR_K8S_SHOW               | Whether the car needs to be shown all the time.                | true                                           |
| BULLETTRAIN_CAR_K8S_TEMPLATE           | The car's template.                                            | `{{.Icon \| printf " %s " \| c}}{{.Context \| c}}` |
| BULLETTRAIN_CAR_K8S_PAINT              | Colour override for the car's paint.                           | white+h:yellow                                       |
| BULLETTRAIN_CAR_K8S_SYMBOL_ICON        | Icon displayed on the car.                                     | `⎈`                                             |
| BULLETTRAIN_CAR_K8S_SEPARATOR_PAINT    | Colour override for the car's right hand side separator paint. | Using default painting algorythm.               |
| BULLETTRAIN_CAR_K8S_SEPARATOR_SYMBOL   | Override the car's right hand side separator symbol.           | Using global symbol.                            |
| BULLETTRAIN_CAR_K8S_SEPARATOR_TEMPLATE | Defines the car separator's template.                          | Using global template.                          |

![Snipaste_2019-05-29_17-55-29](https://user-images.githubusercontent.com/9367842/58547976-016b4780-823b-11e9-8a33-5d22cea2b38d.png)
